### PR TITLE
Add annotations for methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 
-.vscode
 .idea

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm: compile",
+      "type": "npm",
+      "script": "compile",
+      "group": "build",
+      "problemMatcher": ["$tsc"]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   ],
   "scripts": {
     "vscode:prepublish": "npm run package",
+    "vscode:publish": "npx vsce package",
     "compile": "webpack",
     "watch": "webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
-    "lint": "eslint src --ext ts"
+    "lint": "eslint src --ext ts",
+    "lint:fix": "eslint src --ext ts --fix"
   },
   "devDependencies": {
     "@types/glob": "^8.0.0",

--- a/resources/implement.svg
+++ b/resources/implement.svg
@@ -1,0 +1,6 @@
+<svg width="12px" height="12px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="48" fill="#7bc161" stroke="#2a3f48" stroke-width="3" />
+  <text x="50" y="75" font-size="85" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;font-weight: bold;" fill="#2a3f48">
+    I
+  </text>
+</svg>

--- a/resources/override.svg
+++ b/resources/override.svg
@@ -1,0 +1,6 @@
+<svg width="12px" height="12px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="48" fill="#8cd3ec" stroke="#42545c" stroke-width="3" />
+  <text x="50" y="75" font-size="85" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;font-weight: bold;" fill="#42545c">
+    O
+  </text>
+</svg>

--- a/resources/override.svg
+++ b/resources/override.svg
@@ -1,6 +1,0 @@
-<svg width="12px" height="12px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="50" cy="50" r="48" fill="#8cd3ec" stroke="#42545c" stroke-width="3" />
-  <text x="50" y="75" font-size="85" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;font-weight: bold;" fill="#42545c">
-    O
-  </text>
-</svg>

--- a/src/AnnotateLensProvider.ts
+++ b/src/AnnotateLensProvider.ts
@@ -9,15 +9,16 @@ export class AnnotationLensProvider
   public async provideCodeLenses(
     document: vscode.TextDocument
   ): Promise<vscode.CodeLens[]> {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (!activeEditor) {
+      return [];
+    }
+
     const goSymbols = await this.getGoSymbols(document);
 
     const results: AnnotationLens[] = [];
     for (const goSymbol of goSymbols) {
       const symbolInfo = await SymbolInfo.create(goSymbol);
-      const activeEditor = vscode.window.activeTextEditor;
-      if (!activeEditor) {
-        return [];
-      }
 
       const locations = await this.getSymbolLocations(activeEditor, symbolInfo) ?? [];
       const symbols = await Promise.all(locations.map(SymbolInfo.getSymbol));
@@ -27,6 +28,36 @@ export class AnnotationLensProvider
 
       const annotation = new Annotation(symbolInfo.symbol, symbols);
       results.push(new AnnotationLens(annotation));
+
+      for (const child of symbolInfo.symbol.children ?? []) {
+        if (child.kind !== vscode.SymbolKind.Method) {
+          continue;
+        }
+
+        // For methods, get implementation locations directly
+        const methodLocations = await vscode.commands.executeCommand<vscode.Location[]>(
+          "vscode.executeImplementationProvider",
+          activeEditor.document.uri,
+          child.range.start
+        ) ?? [];
+
+        if (methodLocations.length > 0) {
+          const methodSymbols = await Promise.all(methodLocations.map(SymbolInfo.getSymbol));
+
+          // Create location from document and child range
+          const location = new vscode.Location(activeEditor.document.uri, child.range);
+
+          // Convert the child into the combined type needed for Annotation
+          const combinedSymbol = {
+            ...child,
+            location,
+            containerName: symbolInfo.symbol.name
+          } as vscode.SymbolInformation & vscode.DocumentSymbol;
+
+          const methodAnnotation = new Annotation(combinedSymbol, methodSymbols);
+          results.push(new AnnotationLens(methodAnnotation));
+        }
+      }
     }
 
     return results;
@@ -47,7 +78,8 @@ export class AnnotationLensProvider
       (symbol) =>
         symbol.kind === vscode.SymbolKind.Class ||
         symbol.kind === vscode.SymbolKind.Struct ||
-        symbol.kind === vscode.SymbolKind.Interface
+        symbol.kind === vscode.SymbolKind.Interface ||
+        symbol.kind === vscode.SymbolKind.Method
     );
     return symbols;
   }

--- a/src/AnnotateLensProvider.ts
+++ b/src/AnnotateLensProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { Annotation } from "./Annotation";
 import { AnnotationLens } from "./AnnotationLens";
 import { SymbolInfo } from "./SymbolInfo";
-import { getImplementDecoration, getOverrideDecoration } from "./decorations";
+import { getImplementDecoration } from "./decorations";
 
 export class AnnotationLensProvider
   implements vscode.CodeLensProvider<AnnotationLens>

--- a/src/AnnotateLensProvider.ts
+++ b/src/AnnotateLensProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { Annotation } from "./Annotation";
 import { AnnotationLens } from "./AnnotationLens";
 import { SymbolInfo } from "./SymbolInfo";
+import { getImplementDecoration, getOverrideDecoration } from "./decorations";
 
 export class AnnotationLensProvider
   implements vscode.CodeLensProvider<AnnotationLens>
@@ -16,6 +17,8 @@ export class AnnotationLensProvider
 
     const goSymbols = await this.getGoSymbols(document);
 
+    const decorationLocations: vscode.Range[] = [];
+
     const results: AnnotationLens[] = [];
     for (const goSymbol of goSymbols) {
       const symbolInfo = await SymbolInfo.create(goSymbol);
@@ -28,6 +31,14 @@ export class AnnotationLensProvider
 
       const annotation = new Annotation(symbolInfo.symbol, symbols);
       results.push(new AnnotationLens(annotation));
+
+      const decorationRange = new vscode.Range(
+        symbolInfo.symbol.location.range.start,
+        symbolInfo.symbol.location.range.start,
+      );
+      decorationLocations.push(
+        decorationRange,
+      );
 
       for (const child of symbolInfo.symbol.children ?? []) {
         if (child.kind !== vscode.SymbolKind.Method) {
@@ -60,14 +71,27 @@ export class AnnotationLensProvider
       }
     }
 
+    activeEditor.setDecorations(
+      getImplementDecoration(),
+      decorationLocations,
+    );
+
+
     return results;
   }
 
   private async getSymbolLocations(te: vscode.TextEditor, si: SymbolInfo): Promise<vscode.Location[]> {
+    let position = si.symbol.location.range.start;
+    if (si.symbol.kind === vscode.SymbolKind.Method) {
+      position = new vscode.Position(
+        si.symbol.selectionRange.start.line,
+        si.symbol.selectionRange.start.character + 1,
+      );
+    }
     return vscode.commands.executeCommand<vscode.Location[]>(
       "vscode.executeImplementationProvider",
       te.document.uri,
-      si.symbol.location.range.start
+      position,
     );
   }
 

--- a/src/SymbolInfo.ts
+++ b/src/SymbolInfo.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 
 export class SymbolInfo {
   public readonly symbol: vscode.SymbolInformation & vscode.DocumentSymbol;
@@ -15,9 +15,9 @@ export class SymbolInfo {
   ): Promise<vscode.SymbolInformation & vscode.DocumentSymbol> {
     const documentSymbols = (await vscode.commands.executeCommand<
       (vscode.SymbolInformation & vscode.DocumentSymbol)[]
-    >("vscode.executeDocumentSymbolProvider", location.uri))!;
+    >('vscode.executeDocumentSymbolProvider', location.uri))!;
     return documentSymbols.find((documentSymbol) =>
-      documentSymbol.range.start.isEqual(location.range.start)
+      documentSymbol.range.contains(location.range)
     ) as vscode.SymbolInformation & vscode.DocumentSymbol;
   }
 
@@ -29,9 +29,10 @@ export class SymbolInfo {
     if (
       this.symbol.kind !== vscode.SymbolKind.Class &&
       this.symbol.kind !== vscode.SymbolKind.Struct &&
-      this.symbol.kind !== vscode.SymbolKind.Interface
+      this.symbol.kind !== vscode.SymbolKind.Interface &&
+      this.symbol.kind !== vscode.SymbolKind.Method
     ) {
-      throw new Error("Expected struct or interface");
+      throw new Error('Expected struct or interface');
     }
   }
 }

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -1,0 +1,19 @@
+
+import * as vscode from "vscode";
+
+let overrideDecoration = vscode.window.createTextEditorDecorationType({
+    gutterIconPath: __dirname + "/../resources/override.svg",
+    fontWeight: "bold",
+});
+let implementDecoration = vscode.window.createTextEditorDecorationType({
+    gutterIconPath: __dirname + "/../resources/implement.svg",
+    fontWeight: "bold",
+});
+
+export function getOverrideDecoration() {
+    return overrideDecoration;
+}
+
+export function getImplementDecoration() {
+    return implementDecoration;
+}

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -1,18 +1,10 @@
 
 import * as vscode from "vscode";
 
-let overrideDecoration = vscode.window.createTextEditorDecorationType({
-    gutterIconPath: __dirname + "/../resources/override.svg",
-    fontWeight: "bold",
-});
 let implementDecoration = vscode.window.createTextEditorDecorationType({
     gutterIconPath: __dirname + "/../resources/implement.svg",
     fontWeight: "bold",
 });
-
-export function getOverrideDecoration() {
-    return overrideDecoration;
-}
 
 export function getImplementDecoration() {
     return implementDecoration;


### PR DESCRIPTION
Added a implements annotations for the methods of interfaces and their implementations for easier navigation.
Also, added an "I" gutter icon for additional usability enhancements.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/61614a48-6a7d-4a51-8823-639ba6b59ece" />

---

<img width="400" alt="image" src="https://github.com/user-attachments/assets/a7a8e10b-2257-489d-9bef-ff46037cfd9f" />

The PR is not of the highest quality code, but still, we're using it internally. Let me know if you'd like any changes and if we can merge as we'd prefer using the official extension from the marketplace! 🎉 